### PR TITLE
Define TypeScript Types & Interfaces

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,18 @@
 /**
- * Type definitions for Voice2Code extension
+ * Voice2Code Type Definitions
+ * Sprint v1
+ *
+ * All TypeScript interfaces and type definitions for the Voice2Code extension.
+ * Strict typing enforced - no 'any' types allowed.
  */
 
+// ============================================================================
+// Configuration Interfaces
+// ============================================================================
+
+/**
+ * Configuration for STT endpoint connection
+ */
 export interface EndpointConfiguration {
   url: string;
   model: string;
@@ -9,40 +20,92 @@ export interface EndpointConfiguration {
   customHeaders?: Record<string, string>;
 }
 
+/**
+ * Audio capture and encoding configuration
+ */
 export interface AudioConfiguration {
   deviceId: string;
   sampleRate: number;
-  bitDepth: number;
-  channels: number;
   format: 'mp3' | 'wav';
 }
 
+/**
+ * UI preferences and settings
+ */
 export interface UIConfiguration {
-  previewEnabled: boolean;
   showStatusBar: boolean;
-  audioFeedback: boolean;
-  notifyOnError: boolean;
+  showNotifications: boolean;
+  playBeep: boolean;
 }
 
-export interface HistoryConfiguration {
-  enabled: boolean;
-  maxItems: number;
-}
+// ============================================================================
+// Transcription Interfaces
+// ============================================================================
 
+/**
+ * Options for transcription requests
+ */
 export interface TranscriptionOptions {
-  model: string;
   language?: string;
-  prompt?: string;
   temperature?: number;
 }
 
+/**
+ * Result from transcription service
+ */
 export interface TranscriptionResult {
   text: string;
   confidence?: number;
   language?: string;
-  duration?: number;
 }
 
+// ============================================================================
+// Audio Interfaces
+// ============================================================================
+
+/**
+ * Audio input device information
+ */
+export interface AudioDevice {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+// ============================================================================
+// Validation Interfaces
+// ============================================================================
+
+/**
+ * Result of validation operations
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings?: string[];
+}
+
+// ============================================================================
+// State Types
+// ============================================================================
+
+/**
+ * Recording state for the audio capture process
+ */
+export type RecordingState = 'idle' | 'recording' | 'processing';
+
+/**
+ * Transcription state for STT operations
+ */
+export type TranscriptionState = 'pending' | 'in_progress' | 'completed' | 'failed';
+
+// ============================================================================
+// Error Types and Classes
+// ============================================================================
+
+/**
+ * Error codes for Voice2Code operations
+ */
 export type ErrorCode =
   | 'NETWORK_ERROR'
   | 'AUDIO_ERROR'
@@ -50,10 +113,72 @@ export type ErrorCode =
   | 'STT_ERROR'
   | 'VALIDATION_ERROR';
 
-export interface Voice2CodeError {
-  code: ErrorCode;
-  message: string;
-  details?: string;
-  timestamp: number;
-  context?: Record<string, unknown>;
+/**
+ * Base error class for all Voice2Code errors
+ */
+export class Voice2CodeError extends Error {
+  constructor(
+    message: string,
+    public code: ErrorCode,
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = 'Voice2CodeError';
+    Object.setPrototypeOf(this, Voice2CodeError.prototype);
+  }
+}
+
+/**
+ * Network-related errors (connection failures, timeouts, etc.)
+ */
+export class NetworkError extends Voice2CodeError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'NETWORK_ERROR', details);
+    this.name = 'NetworkError';
+    Object.setPrototypeOf(this, NetworkError.prototype);
+  }
+}
+
+/**
+ * Audio capture and encoding errors
+ */
+export class AudioError extends Voice2CodeError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'AUDIO_ERROR', details);
+    this.name = 'AudioError';
+    Object.setPrototypeOf(this, AudioError.prototype);
+  }
+}
+
+/**
+ * Configuration and settings errors
+ */
+export class ConfigurationError extends Voice2CodeError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'CONFIG_ERROR', details);
+    this.name = 'ConfigurationError';
+    Object.setPrototypeOf(this, ConfigurationError.prototype);
+  }
+}
+
+/**
+ * Speech-to-text service errors
+ */
+export class STTError extends Voice2CodeError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'STT_ERROR', details);
+    this.name = 'STTError';
+    Object.setPrototypeOf(this, STTError.prototype);
+  }
+}
+
+/**
+ * Validation errors (invalid input, failed checks, etc.)
+ */
+export class ValidationError extends Voice2CodeError {
+  constructor(message: string, details?: unknown) {
+    super(message, 'VALIDATION_ERROR', details);
+    this.name = 'ValidationError';
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
 }


### PR DESCRIPTION
## Summary

Implements #1: Define TypeScript Types & Interfaces

## Changes

- Created `src/types/index.ts` with all required TypeScript interfaces and types
- Implemented 7 interfaces: EndpointConfiguration, AudioConfiguration, UIConfiguration, TranscriptionOptions, TranscriptionResult, AudioDevice, ValidationResult
- Implemented 2 state types: RecordingState, TranscriptionState  
- Implemented error class hierarchy with 6 classes
- All types use strict typing (no any types)
- Full JSDoc documentation

## Testing

### Type Verification
- ✓ TypeScript compilation verified with `npx tsc --noEmit`
- ✓ No type errors
- ✓ No any types used
- ✓ All error classes properly extend Voice2CodeError

## Checklist

- [x] All interfaces defined in `src/types/index.ts`
- [x] TypeScript strict mode passes
- [x] Error hierarchy implemented
- [x] All types exported properly
- [ ] Code reviewed
- [ ] Ready to merge

## References

- Issue: #1
- Sprint: v1
- Tech Docs: sprints/v1/tech-docs/data-models.md

Closes #1

🤖 Generated with ProdKit