### PR TITLE
feat: implement HistoryManager for session transcription history (#61)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,14 @@
       {
         "command": "voice2code.testConnection",
         "title": "Voice2Code: Test Connection"
+      },
+      {
+        "command": "voice2code.showHistory",
+        "title": "Voice2Code: Show History"
+      },
+      {
+        "command": "voice2code.clearHistory",
+        "title": "Voice2Code: Clear History"
       }
     ],
     "keybindings": [

--- a/src/core/history-manager.ts
+++ b/src/core/history-manager.ts
@@ -1,0 +1,118 @@
+import * as vscode from 'vscode';
+import { HistoryEntry, HistoryStore, PreviewResult } from '../types';
+
+/**
+ * EditorService interface for dependency injection
+ */
+interface EditorService {
+  showPreviewAndInsert(text: string): Promise<PreviewResult>;
+}
+
+/**
+ * HistoryManager
+ *
+ * Stores the last N transcriptions in VS Code globalState so users can
+ * re-insert previous prompts without re-dictating. History persists
+ * across VS Code restarts.
+ *
+ * Storage: context.globalState (user-level, not workspace-level)
+ * Key: 'voice2code.history'
+ */
+export class HistoryManager {
+  private static readonly STORAGE_KEY = 'voice2code.history';
+  private static readonly CONFIG_SECTION = 'voice2code';
+
+  constructor(
+    private context: vscode.ExtensionContext,
+    private editorService: EditorService
+  ) {}
+
+  /**
+   * Add a transcription entry to history
+   *
+   * No-ops if history.enabled is false. Prepends to front,
+   * trims oldest entries when exceeding maxItems.
+   *
+   * @param entry - Entry without id (id is auto-generated)
+   */
+  async add(entry: Omit<HistoryEntry, 'id'>): Promise<void> {
+    const config = vscode.workspace.getConfiguration(HistoryManager.CONFIG_SECTION);
+    if (!config.get<boolean>('history.enabled', false)) {
+      return;
+    }
+
+    const store = this.loadStore();
+    const maxItems = config.get<number>('history.maxItems', 50);
+
+    const newEntry: HistoryEntry = {
+      id: crypto.randomUUID(),
+      ...entry,
+    };
+
+    store.entries.unshift(newEntry);
+
+    if (store.entries.length > maxItems) {
+      store.entries = store.entries.slice(0, maxItems);
+    }
+
+    await this.context.globalState.update(HistoryManager.STORAGE_KEY, store);
+  }
+
+  /**
+   * Get all history entries, most-recent-first
+   *
+   * @returns Array of history entries
+   */
+  getAll(): HistoryEntry[] {
+    return this.loadStore().entries;
+  }
+
+  /**
+   * Clear all history entries
+   */
+  async clear(): Promise<void> {
+    const store: HistoryStore = { version: 1, entries: [] };
+    await this.context.globalState.update(HistoryManager.STORAGE_KEY, store);
+  }
+
+  /**
+   * Show QuickPick with history entries for re-insertion
+   *
+   * Displays formatted list of past transcriptions. On selection,
+   * calls editorService.showPreviewAndInsert to respect preview settings.
+   */
+  async showHistory(): Promise<void> {
+    const entries = this.getAll();
+
+    const items = entries.map((entry) => {
+      const date = new Date(entry.timestamp);
+      const time = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+      const truncated = entry.text.length > 60
+        ? entry.text.slice(0, 60) + '...'
+        : entry.text;
+      const seconds = (entry.durationMs / 1000).toFixed(1);
+
+      return {
+        label: `[${time}] ${truncated}`,
+        description: `${entry.language} · ${seconds}s`,
+        entry,
+      };
+    });
+
+    const selected = await vscode.window.showQuickPick(items, {
+      placeHolder: 'Select a transcription to re-insert',
+    });
+
+    if (selected) {
+      await this.editorService.showPreviewAndInsert(selected.entry.text);
+    }
+  }
+
+  private loadStore(): HistoryStore {
+    const stored = this.context.globalState.get<HistoryStore>(HistoryManager.STORAGE_KEY);
+    if (stored) {
+      return stored;
+    }
+    return { version: 1, entries: [] };
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,37 @@ export interface TranscriptionResult {
   language?: string;
 }
 
+/**
+ * Result of the transcription preview confirmation flow
+ */
+export interface PreviewResult {
+  confirmed: boolean;
+  text: string | null;
+}
+
+// ============================================================================
+// History Interfaces
+// ============================================================================
+
+/**
+ * Single transcription history entry
+ */
+export interface HistoryEntry {
+  id: string;
+  text: string;
+  timestamp: number;
+  language: string;
+  durationMs: number;
+}
+
+/**
+ * Persisted history store structure
+ */
+export interface HistoryStore {
+  version: number;
+  entries: HistoryEntry[];
+}
+
 // ============================================================================
 // Audio Interfaces
 // ============================================================================

--- a/tests/unit/core/engine.test.ts
+++ b/tests/unit/core/engine.test.ts
@@ -36,6 +36,7 @@ class MockConfigurationManager {
       url: 'http://localhost:11434',
       model: 'whisper',
       timeout: 30000,
+      language: 'en',
     };
   }
 }

--- a/tests/unit/core/history-manager.test.ts
+++ b/tests/unit/core/history-manager.test.ts
@@ -1,0 +1,307 @@
+import { HistoryManager } from '../../../src/core/history-manager';
+import { HistoryEntry, HistoryStore } from '../../../src/types';
+import * as vscode from 'vscode';
+
+// Mock vscode module
+jest.mock('vscode', () => ({
+  window: {
+    showQuickPick: jest.fn(),
+    showInformationMessage: jest.fn(),
+  },
+  workspace: {
+    getConfiguration: jest.fn(),
+  },
+}));
+
+// Mock crypto.randomUUID
+const mockRandomUUID = jest.fn();
+Object.defineProperty(globalThis, 'crypto', {
+  value: { randomUUID: mockRandomUUID },
+});
+
+describe('HistoryManager', () => {
+  let manager: HistoryManager;
+  let mockContext: vscode.ExtensionContext;
+  let mockGlobalState: { get: jest.Mock; update: jest.Mock };
+  let mockConfig: { get: jest.Mock };
+  let mockEditorService: { showPreviewAndInsert: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGlobalState = {
+      get: jest.fn().mockReturnValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockContext = {
+      globalState: mockGlobalState,
+    } as unknown as vscode.ExtensionContext;
+
+    mockConfig = { get: jest.fn() };
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue(mockConfig);
+
+    // Default: history enabled, maxItems = 50
+    mockConfig.get.mockImplementation((key: string, defaultValue?: unknown) => {
+      if (key === 'history.enabled') return true;
+      if (key === 'history.maxItems') return 50;
+      return defaultValue;
+    });
+
+    mockEditorService = {
+      showPreviewAndInsert: jest.fn().mockResolvedValue({ confirmed: true, text: 'test' }),
+    };
+
+    mockRandomUUID.mockReturnValue('test-uuid-1');
+
+    manager = new HistoryManager(mockContext, mockEditorService as any);
+  });
+
+  describe('add', () => {
+    it('should prepend new entry to front', async () => {
+      const existingStore: HistoryStore = {
+        version: 1,
+        entries: [
+          { id: 'old-1', text: 'old entry', timestamp: 1000, language: 'en', durationMs: 2000 },
+        ],
+      };
+      mockGlobalState.get.mockReturnValue(existingStore);
+
+      mockRandomUUID.mockReturnValue('new-uuid');
+
+      await manager.add({
+        text: 'new entry',
+        timestamp: 2000,
+        language: 'en',
+        durationMs: 3000,
+      });
+
+      const savedStore = mockGlobalState.update.mock.calls[0][1] as HistoryStore;
+      expect(savedStore.entries[0].text).toBe('new entry');
+      expect(savedStore.entries[0].id).toBe('new-uuid');
+      expect(savedStore.entries[1].text).toBe('old entry');
+    });
+
+    it('should generate UUID for id', async () => {
+      mockRandomUUID.mockReturnValue('generated-uuid-123');
+
+      await manager.add({
+        text: 'test',
+        timestamp: Date.now(),
+        language: 'en',
+        durationMs: 1000,
+      });
+
+      const savedStore = mockGlobalState.update.mock.calls[0][1] as HistoryStore;
+      expect(savedStore.entries[0].id).toBe('generated-uuid-123');
+    });
+
+    it('should trim to maxItems (removes from end)', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'history.enabled') return true;
+        if (key === 'history.maxItems') return 3;
+        return undefined;
+      });
+
+      const existingStore: HistoryStore = {
+        version: 1,
+        entries: [
+          { id: '1', text: 'entry 1', timestamp: 3000, language: 'en', durationMs: 1000 },
+          { id: '2', text: 'entry 2', timestamp: 2000, language: 'en', durationMs: 1000 },
+          { id: '3', text: 'entry 3', timestamp: 1000, language: 'en', durationMs: 1000 },
+        ],
+      };
+      mockGlobalState.get.mockReturnValue(existingStore);
+
+      await manager.add({
+        text: 'new entry',
+        timestamp: 4000,
+        language: 'en',
+        durationMs: 1000,
+      });
+
+      const savedStore = mockGlobalState.update.mock.calls[0][1] as HistoryStore;
+      expect(savedStore.entries.length).toBe(3);
+      expect(savedStore.entries[0].text).toBe('new entry');
+      expect(savedStore.entries[2].text).toBe('entry 2');
+      // entry 3 should be trimmed
+    });
+
+    it('should no-op when history.enabled is false', async () => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'history.enabled') return false;
+        if (key === 'history.maxItems') return 50;
+        return undefined;
+      });
+
+      await manager.add({
+        text: 'test',
+        timestamp: Date.now(),
+        language: 'en',
+        durationMs: 1000,
+      });
+
+      expect(mockGlobalState.update).not.toHaveBeenCalled();
+    });
+
+    it('should persist to globalState', async () => {
+      await manager.add({
+        text: 'test',
+        timestamp: 1234,
+        language: 'fr',
+        durationMs: 5000,
+      });
+
+      expect(mockGlobalState.update).toHaveBeenCalledWith(
+        'voice2code.history',
+        expect.objectContaining({
+          version: 1,
+          entries: expect.arrayContaining([
+            expect.objectContaining({ text: 'test', language: 'fr', durationMs: 5000 }),
+          ]),
+        })
+      );
+    });
+
+    it('should initialize empty store when globalState is empty', async () => {
+      mockGlobalState.get.mockReturnValue(undefined);
+
+      await manager.add({
+        text: 'first entry',
+        timestamp: 1000,
+        language: 'en',
+        durationMs: 2000,
+      });
+
+      const savedStore = mockGlobalState.update.mock.calls[0][1] as HistoryStore;
+      expect(savedStore.version).toBe(1);
+      expect(savedStore.entries.length).toBe(1);
+      expect(savedStore.entries[0].text).toBe('first entry');
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return entries most-recent-first', () => {
+      const store: HistoryStore = {
+        version: 1,
+        entries: [
+          { id: '1', text: 'newest', timestamp: 3000, language: 'en', durationMs: 1000 },
+          { id: '2', text: 'middle', timestamp: 2000, language: 'en', durationMs: 1000 },
+          { id: '3', text: 'oldest', timestamp: 1000, language: 'en', durationMs: 1000 },
+        ],
+      };
+      mockGlobalState.get.mockReturnValue(store);
+
+      const entries = manager.getAll();
+
+      expect(entries[0].text).toBe('newest');
+      expect(entries[2].text).toBe('oldest');
+    });
+
+    it('should return empty array when no history', () => {
+      mockGlobalState.get.mockReturnValue(undefined);
+
+      const entries = manager.getAll();
+
+      expect(entries).toEqual([]);
+    });
+  });
+
+  describe('clear', () => {
+    it('should empty the store in globalState', async () => {
+      await manager.clear();
+
+      expect(mockGlobalState.update).toHaveBeenCalledWith(
+        'voice2code.history',
+        expect.objectContaining({
+          version: 1,
+          entries: [],
+        })
+      );
+    });
+  });
+
+  describe('showHistory', () => {
+    it('should open QuickPick with formatted labels', async () => {
+      const store: HistoryStore = {
+        version: 1,
+        entries: [
+          { id: '1', text: 'Hello world from voice', timestamp: new Date('2026-01-15T14:30:00').getTime(), language: 'en', durationMs: 4200 },
+        ],
+      };
+      mockGlobalState.get.mockReturnValue(store);
+      (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await manager.showHistory();
+
+      const items = (vscode.window.showQuickPick as jest.Mock).mock.calls[0][0];
+      expect(items[0].label).toMatch(/^\[\d{2}:\d{2}\] Hello world from voice$/);
+      expect(items[0].description).toBe('en · 4.2s');
+    });
+
+    it('should truncate labels at 60 chars with ...', async () => {
+      const longText = 'a'.repeat(80);
+      const store: HistoryStore = {
+        version: 1,
+        entries: [
+          { id: '1', text: longText, timestamp: Date.now(), language: 'en', durationMs: 1000 },
+        ],
+      };
+      mockGlobalState.get.mockReturnValue(store);
+      (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await manager.showHistory();
+
+      const items = (vscode.window.showQuickPick as jest.Mock).mock.calls[0][0];
+      // Label should contain truncated text with ...
+      expect(items[0].label).toContain('a'.repeat(60) + '...');
+    });
+
+    it('should call editorService.showPreviewAndInsert on selection', async () => {
+      const entry: HistoryEntry = {
+        id: '1', text: 'selected text', timestamp: Date.now(), language: 'en', durationMs: 2000,
+      };
+      const store: HistoryStore = { version: 1, entries: [entry] };
+      mockGlobalState.get.mockReturnValue(store);
+
+      (vscode.window.showQuickPick as jest.Mock).mockResolvedValue({
+        label: '[14:30] selected text',
+        description: 'en · 2.0s',
+        entry,
+      });
+
+      await manager.showHistory();
+
+      expect(mockEditorService.showPreviewAndInsert).toHaveBeenCalledWith('selected text');
+    });
+
+    it('should use placeholder "Select a transcription to re-insert"', async () => {
+      mockGlobalState.get.mockReturnValue({ version: 1, entries: [] });
+      (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await manager.showHistory();
+
+      expect(vscode.window.showQuickPick).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          placeHolder: 'Select a transcription to re-insert',
+        })
+      );
+    });
+
+    it('should not call editorService when user cancels QuickPick', async () => {
+      const store: HistoryStore = {
+        version: 1,
+        entries: [
+          { id: '1', text: 'test', timestamp: Date.now(), language: 'en', durationMs: 1000 },
+        ],
+      };
+      mockGlobalState.get.mockReturnValue(store);
+      (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+      await manager.showHistory();
+
+      expect(mockEditorService.showPreviewAndInsert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/extension.test.ts
+++ b/tests/unit/extension.test.ts
@@ -6,7 +6,11 @@ jest.mock('vscode', () => ({
   window: {
     showInformationMessage: jest.fn(),
     showErrorMessage: jest.fn(),
+    showWarningMessage: jest.fn(),
     createStatusBarItem: jest.fn(),
+  },
+  workspace: {
+    getConfiguration: jest.fn().mockReturnValue({ get: jest.fn() }),
   },
   commands: {
     registerCommand: jest.fn(),
@@ -25,6 +29,7 @@ jest.mock('../../src/audio/audio-manager');
 jest.mock('../../src/audio/audio-encoder');
 jest.mock('../../src/adapters/adapter-factory');
 jest.mock('../../src/core/engine');
+jest.mock('../../src/core/history-manager');
 
 import { ConfigurationManager } from '../../src/config/configuration-manager';
 import { DeviceManager } from '../../src/audio/device-manager';
@@ -179,10 +184,10 @@ describe('Extension', () => {
       );
     });
 
-    it('should register exactly 5 commands', () => {
+    it('should register exactly 7 commands', () => {
       activate(mockContext);
 
-      expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(5);
+      expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(7);
     });
 
     it('should add all command disposables to context.subscriptions', () => {
@@ -454,7 +459,7 @@ describe('Extension', () => {
       expect(Voice2CodeEngine).toHaveBeenCalled();
 
       // Verify all commands are registered
-      expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(5);
+      expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(7);
 
       // Verify subscriptions are populated
       expect(mockContext.subscriptions.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Implements #61: Implement HistoryManager for session transcription history

## Changes

- Created `src/core/history-manager.ts` with `add()`, `getAll()`, `clear()`, `showHistory()`
- Added `HistoryEntry`, `HistoryStore`, `PreviewResult` interfaces to `types/index.ts`
- Registered `voice2code.showHistory` and `voice2code.clearHistory` commands in `extension.ts` and `package.json`
- History persists in `globalState` (user-level, survives restarts)
- Respects `voice2code.history.enabled` config (default: false)
- QuickPick shows formatted entries with time, truncated text, language, duration
- Re-insertion goes through `showPreviewAndInsert` (respects preview setting)
- `clearHistory` shows confirmation dialog before clearing

## Testing

### Unit Tests (14 new)
- ✓ add() prepends new entry to front
- ✓ add() generates UUID for id
- ✓ add() trims to maxItems (removes from end)
- ✓ add() no-ops when history.enabled is false
- ✓ add() persists to globalState
- ✓ add() initializes empty store when globalState is empty
- ✓ getAll() returns entries most-recent-first
- ✓ getAll() returns empty array when no history
- ✓ clear() empties the store in globalState
- ✓ showHistory() opens QuickPick with formatted labels
- ✓ showHistory() truncates labels at 60 chars with ...
- ✓ showHistory() calls editorService.showPreviewAndInsert on selection
- ✓ showHistory() uses correct placeholder
- ✓ showHistory() does not call editorService when cancelled

### Coverage
- All 365 tests passing
- TypeScript compiles with zero errors

## Checklist

- [x] Tests written and passing
- [x] Code follows design principles (DRY)
- [x] No security vulnerabilities
- [x] Test coverage >= 80%
- [x] JSDoc on all public methods
- [ ] Code reviewed
- [ ] Ready to merge

## References

- Issue: #61
- Sprint: v2
- Sprint Plan: sprints/v2/sprint-plan.md

Closes #61

---

🤖 Generated with ProdKit + Speckit