### PR TITLE
feat: implement ConfigStore for desktop config persistence

### DIFF
--- a/desktop/src/config-store.ts
+++ b/desktop/src/config-store.ts
@@ -1,0 +1,162 @@
+/**
+ * ConfigStore — Typed, validated configuration persistence for the desktop app.
+ * Wraps electron-store with schema validation and maps to shared core types.
+ */
+
+import Store from 'electron-store';
+import {
+  EndpointConfiguration,
+  AudioConfiguration,
+  ConfigurationError,
+} from '@core/types';
+import { validateEndpointUrl, validateModelName } from '@core/config/endpoint-validator';
+
+export interface DesktopConfig {
+  endpoint: {
+    url: string;
+    model: string;
+    timeout: number;
+    language: string;
+  };
+  audio: {
+    sampleRate: number;
+    format: 'mp3' | 'wav';
+  };
+  ui: {
+    showNotifications: boolean;
+  };
+}
+
+type DeepPartial<T> = { [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] };
+
+export const DEFAULT_CONFIG: DesktopConfig = {
+  endpoint: {
+    url: 'http://localhost:8000/v1/audio/transcriptions',
+    model: 'whisper-large-v3',
+    timeout: 30000,
+    language: 'en',
+  },
+  audio: {
+    sampleRate: 16000,
+    format: 'mp3',
+  },
+  ui: {
+    showNotifications: true,
+  },
+};
+
+const VALID_SAMPLE_RATES = [8000, 16000, 22050, 44100];
+const VALID_FORMATS: ReadonlyArray<string> = ['mp3', 'wav'];
+
+export class ConfigStore {
+  private store: Store<DesktopConfig>;
+
+  constructor() {
+    this.store = new Store<DesktopConfig>({
+      name: 'config',
+      defaults: DEFAULT_CONFIG,
+    });
+  }
+
+  getEndpointConfig(): EndpointConfiguration {
+    return {
+      url: this.store.get('endpoint.url') ?? DEFAULT_CONFIG.endpoint.url,
+      model: this.store.get('endpoint.model') ?? DEFAULT_CONFIG.endpoint.model,
+      timeout: this.store.get('endpoint.timeout') ?? DEFAULT_CONFIG.endpoint.timeout,
+      language: this.store.get('endpoint.language') ?? DEFAULT_CONFIG.endpoint.language,
+    };
+  }
+
+  getAudioConfig(): AudioConfiguration {
+    return {
+      deviceId: 'default',
+      sampleRate: this.store.get('audio.sampleRate') ?? DEFAULT_CONFIG.audio.sampleRate,
+      format: (this.store.get('audio.format') ?? DEFAULT_CONFIG.audio.format) as 'mp3' | 'wav',
+    };
+  }
+
+  getUIConfig(): { showNotifications: boolean } {
+    return {
+      showNotifications: this.store.get('ui.showNotifications') ?? DEFAULT_CONFIG.ui.showNotifications,
+    };
+  }
+
+  getAll(): DesktopConfig {
+    return {
+      endpoint: {
+        url: this.store.get('endpoint.url') ?? DEFAULT_CONFIG.endpoint.url,
+        model: this.store.get('endpoint.model') ?? DEFAULT_CONFIG.endpoint.model,
+        timeout: this.store.get('endpoint.timeout') ?? DEFAULT_CONFIG.endpoint.timeout,
+        language: this.store.get('endpoint.language') ?? DEFAULT_CONFIG.endpoint.language,
+      },
+      audio: {
+        sampleRate: this.store.get('audio.sampleRate') ?? DEFAULT_CONFIG.audio.sampleRate,
+        format: (this.store.get('audio.format') ?? DEFAULT_CONFIG.audio.format) as 'mp3' | 'wav',
+      },
+      ui: {
+        showNotifications: this.store.get('ui.showNotifications') ?? DEFAULT_CONFIG.ui.showNotifications,
+      },
+    };
+  }
+
+  save(partial: DeepPartial<DesktopConfig>): void {
+    if (partial.endpoint) {
+      this.saveEndpoint(partial.endpoint);
+    }
+    if (partial.audio) {
+      this.saveAudio(partial.audio);
+    }
+    if (partial.ui) {
+      this.saveUI(partial.ui);
+    }
+  }
+
+  reset(): void {
+    this.store.clear();
+  }
+
+  private saveEndpoint(endpoint: Partial<DesktopConfig['endpoint']>): void {
+    if (endpoint.url !== undefined) {
+      const result = validateEndpointUrl(endpoint.url);
+      if (!result.valid) {
+        throw new ConfigurationError(`Invalid endpoint URL: ${result.errors[0]}`);
+      }
+      this.store.set('endpoint.url', endpoint.url);
+    }
+
+    if (endpoint.model !== undefined) {
+      const result = validateModelName(endpoint.model);
+      if (!result.valid) {
+        throw new ConfigurationError(`Invalid model name: ${result.errors[0]}`);
+      }
+      this.store.set('endpoint.model', endpoint.model);
+    }
+
+    if (endpoint.timeout !== undefined) {
+      const clamped = Math.max(1000, Math.min(120000, endpoint.timeout));
+      this.store.set('endpoint.timeout', clamped);
+    }
+
+    if (endpoint.language !== undefined) {
+      this.store.set('endpoint.language', endpoint.language || 'en');
+    }
+  }
+
+  private saveAudio(audio: Partial<DesktopConfig['audio']>): void {
+    if (audio.sampleRate !== undefined) {
+      const rate = VALID_SAMPLE_RATES.includes(audio.sampleRate) ? audio.sampleRate : 16000;
+      this.store.set('audio.sampleRate', rate);
+    }
+
+    if (audio.format !== undefined) {
+      const fmt = VALID_FORMATS.includes(audio.format) ? audio.format : 'mp3';
+      this.store.set('audio.format', fmt);
+    }
+  }
+
+  private saveUI(ui: Partial<DesktopConfig['ui']>): void {
+    if (ui.showNotifications !== undefined) {
+      this.store.set('ui.showNotifications', ui.showNotifications);
+    }
+  }
+}

--- a/desktop/tests/unit/config-store.test.ts
+++ b/desktop/tests/unit/config-store.test.ts
@@ -1,0 +1,209 @@
+/**
+ * ConfigStore unit tests
+ * TDD: These tests are written BEFORE the implementation.
+ */
+
+// Mock electron-store before importing ConfigStore
+const mockStore = new Map<string, unknown>();
+
+jest.mock('electron-store', () => {
+  return jest.fn().mockImplementation(() => ({
+    get: (key: string) => mockStore.get(key),
+    set: (key: string, value: unknown) => {
+      mockStore.set(key, value);
+    },
+    get store() {
+      return Object.fromEntries(mockStore);
+    },
+    clear: () => {
+      mockStore.clear();
+    },
+    has: (key: string) => mockStore.has(key),
+    delete: (key: string) => mockStore.delete(key),
+  }));
+});
+
+import { ConfigStore, DesktopConfig, DEFAULT_CONFIG } from '../../src/config-store';
+import { EndpointConfiguration, AudioConfiguration, ConfigurationError } from '@core/types';
+
+describe('ConfigStore', () => {
+  let configStore: ConfigStore;
+
+  beforeEach(() => {
+    mockStore.clear();
+    configStore = new ConfigStore();
+  });
+
+  describe('getEndpointConfig', () => {
+    it('should return defaults on fresh store', () => {
+      const config = configStore.getEndpointConfig();
+      expect(config).toEqual<EndpointConfiguration>({
+        url: 'http://localhost:8000/v1/audio/transcriptions',
+        model: 'whisper-large-v3',
+        timeout: 30000,
+        language: 'en',
+      });
+    });
+
+    it('should return saved endpoint config', () => {
+      configStore.save({
+        endpoint: { url: 'http://localhost:9000/v1/audio/transcriptions' },
+      });
+      const config = configStore.getEndpointConfig();
+      expect(config.url).toBe('http://localhost:9000/v1/audio/transcriptions');
+    });
+  });
+
+  describe('getAudioConfig', () => {
+    it('should return defaults with deviceId always "default"', () => {
+      const config = configStore.getAudioConfig();
+      expect(config).toEqual<AudioConfiguration>({
+        deviceId: 'default',
+        sampleRate: 16000,
+        format: 'mp3',
+      });
+    });
+
+    it('should return saved audio config', () => {
+      configStore.save({ audio: { format: 'wav' } });
+      const config = configStore.getAudioConfig();
+      expect(config.format).toBe('wav');
+      expect(config.deviceId).toBe('default');
+    });
+  });
+
+  describe('getUIConfig', () => {
+    it('should return default showNotifications true', () => {
+      const config = configStore.getUIConfig();
+      expect(config.showNotifications).toBe(true);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return complete default config', () => {
+      const config = configStore.getAll();
+      expect(config).toEqual(DEFAULT_CONFIG);
+    });
+  });
+
+  describe('save - endpoint validation', () => {
+    it('should save valid endpoint URL', () => {
+      configStore.save({ endpoint: { url: 'https://api.groq.com/v1/audio/transcriptions' } });
+      expect(configStore.getEndpointConfig().url).toBe('https://api.groq.com/v1/audio/transcriptions');
+    });
+
+    it('should reject invalid endpoint URL (not http/https)', () => {
+      expect(() => {
+        configStore.save({ endpoint: { url: 'ftp://server.com/api' } });
+      }).toThrow(ConfigurationError);
+    });
+
+    it('should reject empty endpoint URL', () => {
+      expect(() => {
+        configStore.save({ endpoint: { url: '' } });
+      }).toThrow(ConfigurationError);
+    });
+
+    it('should save valid model name', () => {
+      configStore.save({ endpoint: { model: 'whisper-large-v3' } });
+      expect(configStore.getEndpointConfig().model).toBe('whisper-large-v3');
+    });
+
+    it('should reject model name with path traversal', () => {
+      expect(() => {
+        configStore.save({ endpoint: { model: '../etc/passwd' } });
+      }).toThrow(ConfigurationError);
+    });
+
+    it('should reject empty model name', () => {
+      expect(() => {
+        configStore.save({ endpoint: { model: '' } });
+      }).toThrow(ConfigurationError);
+    });
+  });
+
+  describe('save - timeout clamping', () => {
+    it('should clamp timeout below minimum to 1000', () => {
+      configStore.save({ endpoint: { timeout: 500 } });
+      expect(configStore.getEndpointConfig().timeout).toBe(1000);
+    });
+
+    it('should clamp timeout above maximum to 120000', () => {
+      configStore.save({ endpoint: { timeout: 200000 } });
+      expect(configStore.getEndpointConfig().timeout).toBe(120000);
+    });
+
+    it('should accept valid timeout', () => {
+      configStore.save({ endpoint: { timeout: 15000 } });
+      expect(configStore.getEndpointConfig().timeout).toBe(15000);
+    });
+  });
+
+  describe('save - audio validation', () => {
+    it('should default invalid audio format to mp3', () => {
+      configStore.save({ audio: { format: 'ogg' as 'mp3' | 'wav' } });
+      expect(configStore.getAudioConfig().format).toBe('mp3');
+    });
+
+    it('should default invalid sample rate to 16000', () => {
+      configStore.save({ audio: { sampleRate: 48000 } });
+      expect(configStore.getAudioConfig().sampleRate).toBe(16000);
+    });
+
+    it('should accept valid sample rate', () => {
+      configStore.save({ audio: { sampleRate: 44100 } });
+      expect(configStore.getAudioConfig().sampleRate).toBe(44100);
+    });
+
+    it('should accept valid format wav', () => {
+      configStore.save({ audio: { format: 'wav' } });
+      expect(configStore.getAudioConfig().format).toBe('wav');
+    });
+  });
+
+  describe('save - deep merge', () => {
+    it('should not overwrite unrelated fields when saving partial config', () => {
+      configStore.save({ endpoint: { url: 'http://localhost:9000/api' } });
+      configStore.save({ audio: { format: 'wav' } });
+
+      const config = configStore.getEndpointConfig();
+      expect(config.url).toBe('http://localhost:9000/api');
+      expect(configStore.getAudioConfig().format).toBe('wav');
+    });
+
+    it('should not overwrite endpoint model when saving endpoint url', () => {
+      configStore.save({ endpoint: { model: 'custom-model' } });
+      configStore.save({ endpoint: { url: 'http://localhost:9000/api' } });
+
+      const config = configStore.getEndpointConfig();
+      expect(config.model).toBe('custom-model');
+      expect(config.url).toBe('http://localhost:9000/api');
+    });
+  });
+
+  describe('save - language', () => {
+    it('should save valid language code', () => {
+      configStore.save({ endpoint: { language: 'fr' } });
+      expect(configStore.getEndpointConfig().language).toBe('fr');
+    });
+
+    it('should default empty language to en', () => {
+      configStore.save({ endpoint: { language: '' } });
+      expect(configStore.getEndpointConfig().language).toBe('en');
+    });
+  });
+
+  describe('reset', () => {
+    it('should restore all defaults', () => {
+      configStore.save({
+        endpoint: { url: 'https://api.groq.com/test', model: 'custom', timeout: 5000, language: 'fr' },
+        audio: { format: 'wav', sampleRate: 44100 },
+        ui: { showNotifications: false },
+      });
+
+      configStore.reset();
+
+      expect(configStore.getAll()).toEqual(DEFAULT_CONFIG);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #72: [P0][feature] Implement ConfigStore for desktop config persistence

- Wraps `electron-store` with typed schema validation using shared `@core` validators
- Supports endpoint (URL, model, timeout, language), audio (sampleRate, format), and UI config
- Deep partial saves — update individual fields without overwriting others
- Timeout clamping (1s-120s), audio format/sampleRate defaults on invalid input

## Testing

### Unit Tests (24 passing, 100% coverage)
- Default config retrieval (endpoint, audio, UI, getAll)
- Save/retrieve round-trips for all fields
- URL validation (rejects ftp://, empty)
- Model name validation (rejects path traversal, empty)
- Timeout clamping (min 1000, max 120000)
- Audio format/sampleRate defaults on invalid values
- Deep merge (partial saves don't overwrite sibling fields)
- Language defaults empty to en
- Reset restores all defaults

## Checklist

- [x] Tests written first (TDD)
- [x] All 24 tests passing
- [x] 100% code coverage
- [x] Uses shared validators from @core/config
- [x] No security vulnerabilities

Closes #72
