### PR TITLE
feat: implement SecretStore for encrypted API key management

### DIFF
--- a/desktop/src/secret-store.ts
+++ b/desktop/src/secret-store.ts
@@ -1,0 +1,61 @@
+/**
+ * SecretStore — Encrypts and manages API keys using Electron's safeStorage API.
+ * Encrypted blobs are stored as base64 strings in electron-store.
+ */
+
+import { safeStorage } from 'electron';
+import Store from 'electron-store';
+import { ConfigurationError } from '@core/types';
+
+const ENCRYPTED_KEY = '_encryptedApiKey';
+
+export class SecretStore {
+  constructor(private store: Store) {}
+
+  setApiKey(apiKey: string): void {
+    const trimmed = apiKey.trim();
+    if (!trimmed) {
+      throw new ConfigurationError('API key cannot be empty');
+    }
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new ConfigurationError(
+        'Secure storage is not available. Cannot store API key.'
+      );
+    }
+    const encrypted = safeStorage.encryptString(trimmed);
+    this.store.set(ENCRYPTED_KEY, encrypted.toString('base64'));
+  }
+
+  getApiKey(): string | null {
+    const base64 = this.store.get(ENCRYPTED_KEY) as string | undefined;
+    if (!base64) {
+      return null;
+    }
+    try {
+      const buffer = Buffer.from(base64, 'base64');
+      return safeStorage.decryptString(buffer);
+    } catch {
+      this.store.delete(ENCRYPTED_KEY);
+      return null;
+    }
+  }
+
+  deleteApiKey(): void {
+    this.store.delete(ENCRYPTED_KEY);
+  }
+
+  hasApiKey(): boolean {
+    return this.store.has(ENCRYPTED_KEY);
+  }
+
+  getApiKeyMasked(): string | null {
+    const key = this.getApiKey();
+    if (!key) {
+      return null;
+    }
+    if (key.length <= 4) {
+      return '****';
+    }
+    return '*'.repeat(key.length - 4) + key.slice(-4);
+  }
+}

--- a/desktop/tests/unit/secret-store.test.ts
+++ b/desktop/tests/unit/secret-store.test.ts
@@ -1,0 +1,142 @@
+/**
+ * SecretStore unit tests
+ * TDD: These tests are written BEFORE the implementation.
+ */
+
+// Mock electron-store before importing SecretStore
+const mockStore = new Map<string, unknown>();
+
+jest.mock('electron-store', () => {
+  return jest.fn().mockImplementation(() => ({
+    get: (key: string) => mockStore.get(key),
+    set: (key: string, value: unknown) => {
+      mockStore.set(key, value);
+    },
+    has: (key: string) => mockStore.has(key),
+    delete: (key: string) => mockStore.delete(key),
+    clear: () => mockStore.clear(),
+  }));
+});
+
+import Store from 'electron-store';
+import { safeStorage } from 'electron';
+import { SecretStore } from '../../src/secret-store';
+import { ConfigurationError } from '@core/types';
+
+describe('SecretStore', () => {
+  let secretStore: SecretStore;
+  let store: Store;
+
+  beforeEach(() => {
+    mockStore.clear();
+    jest.clearAllMocks();
+    (safeStorage.isEncryptionAvailable as jest.Mock).mockReturnValue(true);
+    store = new Store();
+    secretStore = new SecretStore(store);
+  });
+
+  describe('setApiKey + getApiKey', () => {
+    it('should store and retrieve an API key', () => {
+      secretStore.setApiKey('sk-test-abc123');
+      const result = secretStore.getApiKey();
+      expect(result).toBe('sk-test-abc123');
+    });
+
+    it('should trim whitespace before encrypting', () => {
+      secretStore.setApiKey('  sk-trimmed  ');
+      const result = secretStore.getApiKey();
+      expect(result).toBe('sk-trimmed');
+    });
+
+    it('should overwrite existing key with new one', () => {
+      secretStore.setApiKey('old-key');
+      secretStore.setApiKey('new-key');
+      expect(secretStore.getApiKey()).toBe('new-key');
+    });
+  });
+
+  describe('getApiKey', () => {
+    it('should return null when no key stored', () => {
+      expect(secretStore.getApiKey()).toBeNull();
+    });
+
+    it('should return null and delete on decryption failure', () => {
+      // Store corrupt data directly
+      mockStore.set('_encryptedApiKey', 'corrupt-not-real-base64');
+      (safeStorage.decryptString as jest.Mock).mockImplementationOnce(() => {
+        throw new Error('Decryption failed');
+      });
+
+      const result = secretStore.getApiKey();
+      expect(result).toBeNull();
+      expect(mockStore.has('_encryptedApiKey')).toBe(false);
+    });
+  });
+
+  describe('setApiKey - validation', () => {
+    it('should reject empty API key', () => {
+      expect(() => secretStore.setApiKey('')).toThrow(ConfigurationError);
+      expect(() => secretStore.setApiKey('')).toThrow('API key cannot be empty');
+    });
+
+    it('should reject whitespace-only API key', () => {
+      expect(() => secretStore.setApiKey('   ')).toThrow(ConfigurationError);
+      expect(() => secretStore.setApiKey('   ')).toThrow('API key cannot be empty');
+    });
+
+    it('should throw when safeStorage is unavailable', () => {
+      (safeStorage.isEncryptionAvailable as jest.Mock).mockReturnValue(false);
+      expect(() => secretStore.setApiKey('sk-valid')).toThrow(ConfigurationError);
+      expect(() => secretStore.setApiKey('sk-valid')).toThrow(
+        'Secure storage is not available. Cannot store API key.'
+      );
+    });
+  });
+
+  describe('deleteApiKey', () => {
+    it('should delete stored key', () => {
+      secretStore.setApiKey('sk-to-delete');
+      expect(secretStore.hasApiKey()).toBe(true);
+      secretStore.deleteApiKey();
+      expect(secretStore.hasApiKey()).toBe(false);
+      expect(secretStore.getApiKey()).toBeNull();
+    });
+
+    it('should not throw when deleting non-existent key', () => {
+      expect(() => secretStore.deleteApiKey()).not.toThrow();
+    });
+  });
+
+  describe('hasApiKey', () => {
+    it('should return false when no key stored', () => {
+      expect(secretStore.hasApiKey()).toBe(false);
+    });
+
+    it('should return true when key is stored', () => {
+      secretStore.setApiKey('sk-exists');
+      expect(secretStore.hasApiKey()).toBe(true);
+    });
+  });
+
+  describe('getApiKeyMasked', () => {
+    it('should return null when no key stored', () => {
+      expect(secretStore.getApiKeyMasked()).toBeNull();
+    });
+
+    it('should mask long key showing last 4 chars', () => {
+      secretStore.setApiKey('sk-abc123xyz');
+      const masked = secretStore.getApiKeyMasked();
+      expect(masked).toBe('********3xyz');
+    });
+
+    it('should mask short key (4 chars or less) as ****', () => {
+      secretStore.setApiKey('abcd');
+      expect(secretStore.getApiKeyMasked()).toBe('****');
+    });
+
+    it('should mask 5-char key showing last 4', () => {
+      secretStore.setApiKey('abcde');
+      expect(secretStore.getApiKeyMasked()).toBe('*bcde');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #73: [P0][feature] Implement SecretStore for encrypted API key management

- Uses Electron `safeStorage` API (macOS Keychain-backed encryption)
- Encrypts API keys to base64 blobs stored in electron-store
- Validates non-empty keys and safeStorage availability
- Graceful corruption handling (deletes corrupt data, returns null)
- Masked display for settings UI (`********3xyz`)

## Testing

### Unit Tests (16 passing, 100% coverage)
- Store/retrieve API key round-trip
- Whitespace trimming
- Key overwrite
- Null on empty store
- Corrupt data handling (delete + return null)
- Empty/whitespace validation (throws ConfigurationError)
- safeStorage unavailability (throws ConfigurationError)
- Delete and hasApiKey operations
- Masked key display (long keys, short keys, 5-char edge case)

## Checklist

- [x] Tests written first (TDD)
- [x] All 16 tests passing
- [x] 100% code coverage
- [x] No plain-text API keys in logs or config
- [x] Graceful corruption handling

Closes #73
