### PR TITLE
feat: implement HotkeyManager for global keyboard shortcut

### DIFF
--- a/desktop/src/hotkey.ts
+++ b/desktop/src/hotkey.ts
@@ -1,0 +1,32 @@
+/**
+ * HotkeyManager — Registers and manages global keyboard shortcuts
+ * using Electron's globalShortcut API.
+ */
+
+import { globalShortcut } from 'electron';
+
+export class HotkeyManager {
+  private registered = false;
+
+  constructor(private accelerator: string = 'CommandOrControl+Shift+V') {}
+
+  register(callback: () => void): boolean {
+    if (this.registered) {
+      this.unregister();
+    }
+    const success = globalShortcut.register(this.accelerator, callback);
+    this.registered = success;
+    return success;
+  }
+
+  unregister(): void {
+    if (this.registered) {
+      globalShortcut.unregister(this.accelerator);
+      this.registered = false;
+    }
+  }
+
+  isRegistered(): boolean {
+    return this.registered;
+  }
+}

--- a/desktop/tests/unit/hotkey.test.ts
+++ b/desktop/tests/unit/hotkey.test.ts
@@ -1,0 +1,115 @@
+/**
+ * HotkeyManager unit tests
+ * TDD: These tests are written BEFORE the implementation.
+ */
+
+import { globalShortcut } from 'electron';
+import { HotkeyManager } from '../../src/hotkey';
+
+const mockGlobalShortcut = globalShortcut as unknown as {
+  register: jest.Mock;
+  unregister: jest.Mock;
+  unregisterAll: jest.Mock;
+  isRegistered: jest.Mock;
+};
+
+describe('HotkeyManager', () => {
+  let hotkeyManager: HotkeyManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGlobalShortcut.register.mockReturnValue(true);
+    mockGlobalShortcut.isRegistered.mockReturnValue(false);
+    hotkeyManager = new HotkeyManager();
+  });
+
+  afterEach(() => {
+    hotkeyManager.unregister();
+  });
+
+  describe('register', () => {
+    it('should register shortcut successfully and return true', () => {
+      const callback = jest.fn();
+      const result = hotkeyManager.register(callback);
+
+      expect(result).toBe(true);
+      expect(mockGlobalShortcut.register).toHaveBeenCalledWith(
+        'CommandOrControl+Shift+V',
+        callback
+      );
+    });
+
+    it('should return false when globalShortcut.register fails', () => {
+      mockGlobalShortcut.register.mockReturnValue(false);
+      const callback = jest.fn();
+
+      const result = hotkeyManager.register(callback);
+
+      expect(result).toBe(false);
+    });
+
+    it('should use custom accelerator when provided', () => {
+      const custom = new HotkeyManager('CommandOrControl+Shift+R');
+      const callback = jest.fn();
+      custom.register(callback);
+
+      expect(mockGlobalShortcut.register).toHaveBeenCalledWith(
+        'CommandOrControl+Shift+R',
+        callback
+      );
+      custom.unregister();
+    });
+
+    it('should unregister old shortcut before re-registering', () => {
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      hotkeyManager.register(callback1);
+      hotkeyManager.register(callback2);
+
+      expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith(
+        'CommandOrControl+Shift+V'
+      );
+    });
+  });
+
+  describe('unregister', () => {
+    it('should unregister shortcut when registered', () => {
+      hotkeyManager.register(jest.fn());
+      jest.clearAllMocks();
+
+      hotkeyManager.unregister();
+
+      expect(mockGlobalShortcut.unregister).toHaveBeenCalledWith(
+        'CommandOrControl+Shift+V'
+      );
+    });
+
+    it('should not throw when unregistering without prior registration', () => {
+      expect(() => hotkeyManager.unregister()).not.toThrow();
+    });
+  });
+
+  describe('isRegistered', () => {
+    it('should return false initially', () => {
+      expect(hotkeyManager.isRegistered()).toBe(false);
+    });
+
+    it('should return true after successful registration', () => {
+      hotkeyManager.register(jest.fn());
+      expect(hotkeyManager.isRegistered()).toBe(true);
+    });
+
+    it('should return false after unregister', () => {
+      hotkeyManager.register(jest.fn());
+      hotkeyManager.unregister();
+      expect(hotkeyManager.isRegistered()).toBe(false);
+    });
+
+    it('should return false when registration fails', () => {
+      mockGlobalShortcut.register.mockReturnValue(false);
+      hotkeyManager.register(jest.fn());
+      expect(hotkeyManager.isRegistered()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #75: HotkeyManager for global keyboard shortcut

- Wraps Electron globalShortcut API
- Default accelerator: Cmd+Shift+V (configurable)
- Safe re-registration (unregisters old before new)
- Clean unregister on destroy

## Testing

10 unit tests, 100% coverage

Closes #75