### PR TITLE
feat: create Settings UI (HTML/CSS/renderer)

### DIFF
--- a/desktop/src/settings/settings-renderer.ts
+++ b/desktop/src/settings/settings-renderer.ts
@@ -1,2 +1,136 @@
-// Settings renderer — implemented in Issue #80
-export {};
+/**
+ * Settings renderer — communicates with main process via settingsAPI bridge.
+ */
+
+declare global {
+  interface Window {
+    settingsAPI: {
+      getConfig(): Promise<{
+        endpoint: { url: string; model: string; timeout: number; language: string };
+        audio: { sampleRate: number; format: string };
+        ui: { showNotifications: boolean };
+      }>;
+      saveConfig(config: unknown): Promise<{ success: boolean; error?: string }>;
+      getApiKeyMasked(): Promise<string | null>;
+      setApiKey(apiKey: string): Promise<{ success: boolean; error?: string }>;
+      deleteApiKey(): Promise<{ success: boolean }>;
+      testConnection(): Promise<{ success: boolean; latencyMs?: number; error?: string }>;
+    };
+  }
+}
+
+const $ = (id: string) => document.getElementById(id)!;
+
+function showStatus(el: HTMLElement, message: string, type: 'success' | 'error' | 'info') {
+  el.textContent = message;
+  el.className = `status ${type}`;
+  if (type !== 'info') {
+    setTimeout(() => { el.textContent = ''; el.className = 'status'; }, 3000);
+  }
+}
+
+function setButtonsDisabled(disabled: boolean, ...buttons: HTMLButtonElement[]) {
+  buttons.forEach(btn => btn.disabled = disabled);
+}
+
+async function loadConfig() {
+  const config = await window.settingsAPI.getConfig();
+
+  ($ ('endpoint-url') as HTMLInputElement).value = config.endpoint.url;
+  ($('endpoint-model') as HTMLInputElement).value = config.endpoint.model;
+  ($('endpoint-language') as HTMLInputElement).value = config.endpoint.language;
+  ($('endpoint-timeout') as HTMLInputElement).value = String(config.endpoint.timeout);
+
+  ($('audio-format') as HTMLSelectElement).value = config.audio.format;
+  ($('audio-sample-rate') as HTMLSelectElement).value = String(config.audio.sampleRate);
+}
+
+async function loadApiKeyStatus() {
+  const masked = await window.settingsAPI.getApiKeyMasked();
+  const statusEl = $('api-key-status');
+  if (masked) {
+    showStatus(statusEl, `Key: ${masked}`, 'info');
+  } else {
+    showStatus(statusEl, 'No API key stored', 'info');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadConfig();
+  await loadApiKeyStatus();
+
+  const btnSave = $('btn-save-settings') as HTMLButtonElement;
+  const btnTest = $('btn-test-connection') as HTMLButtonElement;
+  const btnSaveKey = $('btn-save-api-key') as HTMLButtonElement;
+  const btnDeleteKey = $('btn-delete-api-key') as HTMLButtonElement;
+
+  // Save Settings
+  btnSave.addEventListener('click', async () => {
+    setButtonsDisabled(true, btnSave);
+    const config = {
+      endpoint: {
+        url: ($('endpoint-url') as HTMLInputElement).value,
+        model: ($('endpoint-model') as HTMLInputElement).value,
+        language: ($('endpoint-language') as HTMLInputElement).value,
+        timeout: parseInt(($('endpoint-timeout') as HTMLInputElement).value, 10),
+      },
+      audio: {
+        format: ($('audio-format') as HTMLSelectElement).value,
+        sampleRate: parseInt(($('audio-sample-rate') as HTMLSelectElement).value, 10),
+      },
+    };
+
+    const result = await window.settingsAPI.saveConfig(config);
+    const statusEl = $('save-status');
+    if (result.success) {
+      showStatus(statusEl, 'Saved', 'success');
+    } else {
+      showStatus(statusEl, result.error || 'Failed to save', 'error');
+    }
+    setButtonsDisabled(false, btnSave);
+  });
+
+  // Test Connection
+  btnTest.addEventListener('click', async () => {
+    setButtonsDisabled(true, btnTest);
+    const statusEl = $('test-connection-status');
+    showStatus(statusEl, 'Testing...', 'info');
+
+    const result = await window.settingsAPI.testConnection();
+    if (result.success) {
+      showStatus(statusEl, `Connected (${result.latencyMs}ms)`, 'success');
+    } else {
+      showStatus(statusEl, result.error || 'Connection failed', 'error');
+    }
+    setButtonsDisabled(false, btnTest);
+  });
+
+  // Save API Key
+  btnSaveKey.addEventListener('click', async () => {
+    const input = $('api-key-input') as HTMLInputElement;
+    const apiKey = input.value;
+    if (!apiKey.trim()) return;
+
+    setButtonsDisabled(true, btnSaveKey, btnDeleteKey);
+    const result = await window.settingsAPI.setApiKey(apiKey);
+    const statusEl = $('api-key-status');
+
+    if (result.success) {
+      input.value = '';
+      await loadApiKeyStatus();
+      showStatus(statusEl, `Key saved`, 'success');
+    } else {
+      showStatus(statusEl, result.error || 'Failed to save key', 'error');
+    }
+    setButtonsDisabled(false, btnSaveKey, btnDeleteKey);
+  });
+
+  // Delete API Key
+  btnDeleteKey.addEventListener('click', async () => {
+    setButtonsDisabled(true, btnSaveKey, btnDeleteKey);
+    await window.settingsAPI.deleteApiKey();
+    const statusEl = $('api-key-status');
+    showStatus(statusEl, 'No API key stored', 'info');
+    setButtonsDisabled(false, btnSaveKey, btnDeleteKey);
+  });
+});

--- a/desktop/src/settings/settings.css
+++ b/desktop/src/settings/settings.css
@@ -1,5 +1,3 @@
-/* Settings styles — implemented in Issue #80 */
-
 * {
   margin: 0;
   padding: 0;
@@ -17,4 +15,143 @@ body {
 .container {
   max-width: 520px;
   margin: 0 auto;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+h2 {
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 12px;
+}
+
+.section {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.field {
+  margin-bottom: 12px;
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+label {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: #666;
+  margin-bottom: 4px;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"],
+select {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+input:focus,
+select:focus {
+  border-color: #0071e3;
+  box-shadow: 0 0 0 2px rgba(0, 113, 227, 0.15);
+}
+
+.field-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.field-row .field {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+button {
+  padding: 8px 16px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  background: #fff;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+button:hover {
+  background: #f0f0f0;
+}
+
+button:active {
+  background: #e0e0e0;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #0071e3;
+  color: #fff;
+  border-color: #0071e3;
+  width: 100%;
+}
+
+.btn-primary:hover {
+  background: #0062cc;
+}
+
+.btn-danger {
+  color: #d33;
+  border-color: #d33;
+}
+
+.btn-danger:hover {
+  background: #fef0f0;
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+}
+
+.status {
+  display: inline-block;
+  font-size: 12px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.status.success {
+  color: #28a745;
+}
+
+.status.error {
+  color: #d33;
+}
+
+.status.info {
+  color: #666;
 }

--- a/desktop/src/settings/settings.html
+++ b/desktop/src/settings/settings.html
@@ -10,8 +10,82 @@
 <body>
   <div class="container">
     <h1>Voice2Code Settings</h1>
-    <p>Settings UI — implemented in Issue #80</p>
+
+    <!-- Endpoint Section -->
+    <section class="section">
+      <h2>Endpoint</h2>
+      <div class="field">
+        <label for="endpoint-url">URL</label>
+        <input type="text" id="endpoint-url" placeholder="http://localhost:8000/v1/audio/transcriptions">
+      </div>
+      <div class="field">
+        <label for="endpoint-model">Model</label>
+        <input type="text" id="endpoint-model" placeholder="whisper-large-v3">
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label for="endpoint-language">Language</label>
+          <input type="text" id="endpoint-language" maxlength="5" placeholder="en">
+        </div>
+        <div class="field">
+          <label for="endpoint-timeout">Timeout (ms)</label>
+          <input type="number" id="endpoint-timeout" min="1000" max="120000" step="1000">
+        </div>
+      </div>
+      <div class="field">
+        <button id="btn-test-connection" type="button">Test Connection</button>
+        <span id="test-connection-status" class="status"></span>
+      </div>
+    </section>
+
+    <!-- API Key Section -->
+    <section class="section">
+      <h2>API Key</h2>
+      <div class="field">
+        <label for="api-key-input">API Key</label>
+        <input type="password" id="api-key-input" placeholder="Enter API key">
+      </div>
+      <div class="field">
+        <span id="api-key-status" class="status">No API key stored</span>
+      </div>
+      <div class="button-row">
+        <button id="btn-save-api-key" type="button">Save API Key</button>
+        <button id="btn-delete-api-key" type="button" class="btn-danger">Delete API Key</button>
+      </div>
+    </section>
+
+    <!-- Audio Section -->
+    <section class="section">
+      <h2>Audio</h2>
+      <div class="field-row">
+        <div class="field">
+          <label for="audio-format">Format</label>
+          <select id="audio-format">
+            <option value="mp3">MP3</option>
+            <option value="wav">WAV</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="audio-sample-rate">Sample Rate</label>
+          <select id="audio-sample-rate">
+            <option value="8000">8000 Hz</option>
+            <option value="16000">16000 Hz</option>
+            <option value="22050">22050 Hz</option>
+            <option value="44100">44100 Hz</option>
+          </select>
+        </div>
+      </div>
+    </section>
+
+    <!-- Save Section -->
+    <section class="section">
+      <div class="field">
+        <button id="btn-save-settings" type="button" class="btn-primary">Save Settings</button>
+        <span id="save-status" class="status"></span>
+      </div>
+    </section>
   </div>
+
   <script src="settings-renderer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Implements #80: Settings UI with HTML form, CSS styles, and renderer

- Endpoint section: URL, model, language, timeout, Test Connection
- API Key section: password input, save/delete, masked display
- Audio section: format (MP3/WAV), sample rate select
- Save Settings button with status feedback
- CSP meta tag, native macOS styling
- Auto-clearing status messages, disabled states during async ops

## Testing

No unit tests (renderer UI). All 126 existing tests pass.

Closes #80